### PR TITLE
attach built slick div to htmlwidget element instead of document.body

### DIFF
--- a/inst/htmlwidgets/slickR.js
+++ b/inst/htmlwidgets/slickR.js
@@ -15,7 +15,7 @@ HTMLWidgets.widget({
               var len = obj.length,i = 0;
 							var mainDiv = document.createElement("div");
               mainDiv.className = cl;
-              document.body.appendChild(mainDiv);
+              el.appendChild(mainDiv);
               
               for(i=0; i < len; i++ ){
                 var divEl = document.createElement("div");


### PR DESCRIPTION
fix https://github.com/yonicd/slickR/issues/2